### PR TITLE
Feature: Login Endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 This repository contains back end code for a PostgreSQL database, **made for educational purposes**. At this time, **it is not yet feature-complete**, and while you are free to fork the codebase and use it for your own personal projects, **do not expect support of any kind!** You have been warned.
 
+### Endpoints
+
+Documentation related to available endpoints can be found in the `endpoints.md` file, located [here](endpoints.md).
+
 ### ☝️ **Pitch**
 
 These days, fitness classes can be held anywhere- a park, an unfinished basement or a garage- not just at a traditional gym. Certified fitness instructors need an easy way to take the awkwardness out of attendance taking and client payment processing.

--- a/api/auth/auth-router.js
+++ b/api/auth/auth-router.js
@@ -3,11 +3,13 @@ const bcrypt = require("bcryptjs")
 
 const User = require("../users/users-model")
 const { BCRYPT_ROUNDS } = require("../../config")
-// const buildToken = require("./token-builder")
+const buildToken = require("./token-builder")
 const {
+  validateLogin,
   validateRegistration
 } = require("../middleware/validate-credentials")
 const {
+  checkUserExists,
   checkUsernameTaken
 } = require("../middleware/check-username")
 
@@ -16,7 +18,8 @@ router.post("/register",
   checkUsernameTaken,
   async (req, res, next) => {
     try {
-      let registrationInfo = req.custom_registration
+      const { username, password, email } = req.body
+      let registrationInfo = { username, password, email }
       const hash = bcrypt.hashSync(registrationInfo.password, BCRYPT_ROUNDS)
       registrationInfo.password = hash
 
@@ -25,6 +28,32 @@ router.post("/register",
         message: "New user registered, successfully!",
         user: newUser
       })
+    } catch (err) {
+      next(err)
+    }
+  }
+)
+
+router.post("/login",
+  validateLogin,
+  checkUserExists,
+  async (req, res, next) => {
+    try {
+      const { password } = req.body
+      const user = req.custom_existingUser
+      const passwordIsValid = bcrypt.compareSync(password, user.password)
+
+      if (passwordIsValid) {
+        res.status(200).json({
+          message: `Welcome, ${user.username}!`,
+          token: buildToken(user)
+        })
+      } else {
+        next({
+          status: 400,
+          message: "Invalid Credentials!"
+        })
+      }
     } catch (err) {
       next(err)
     }

--- a/api/middleware/check-username.js
+++ b/api/middleware/check-username.js
@@ -1,7 +1,7 @@
 const User = require("../users/users-model")
 
 const checkUserExists = async (req, res, next) => {
-  const { username } = req.custom_login
+  const { username } = req.body
   const users = await User.filterBy({ username })
   if (users.length === 0) {
     next({
@@ -15,7 +15,7 @@ const checkUserExists = async (req, res, next) => {
 }
 
 const checkUsernameTaken = async (req, res, next) => {
-  const { username } = req.custom_registration
+  const { username } = req.body
   const users = await User.filterBy({ username })
   if (users.length !== 0) {
     next({

--- a/api/middleware/validate-credentials.js
+++ b/api/middleware/validate-credentials.js
@@ -6,12 +6,7 @@ const {
 const validateRegistration = async (req, res, next) => {
   try {
     const payload = req.body
-    const validatedPayload = await registerSchema.validate(payload)
-    req.custom_registration = {
-      username: validatedPayload.username,
-      password: validatedPayload.password,
-      email: validatedPayload.email
-    }
+    await registerSchema.validate(payload)
     next()
   } catch (err) {
     next({
@@ -24,8 +19,7 @@ const validateRegistration = async (req, res, next) => {
 const validateLogin = async (req, res, next) => {
   try {
     const payload = req.body
-    const validatedPayload = await loginSchema.validate(payload)
-    req.custom_login = validatedPayload
+    await loginSchema.validate(payload)
     next()
   } catch (err) {
     next({

--- a/api/server.spec.js
+++ b/api/server.spec.js
@@ -57,7 +57,6 @@ describe("[POST] /api/auth/register", () => {
 
       expect(actualMessage).toMatch(expectedMessage)
       expect(actualUser).toMatchObject(expectedUser)
-      expect(actualUser).toHaveProperty("password")
     })
   })
 
@@ -95,6 +94,7 @@ describe("[POST] /api/auth/register", () => {
 
         expect(actual).toMatch(expected)
       })
+
       it("returns 'username must be 6 characters or longer' when username is too short", async () => {
         const expected = /username must be 6 characters or longer/i
         registration.username = "short"
@@ -106,9 +106,22 @@ describe("[POST] /api/auth/register", () => {
 
         expect(actual).toMatch(expected)
       })
+
       it("returns 'username must be shorter than 32 characters' when username is too long", async () => {
         const expected = /username must be shorter than 32 characters/i
         registration.username = "thisusernameiswaaaaaaaaaaaaaaaaaaaaaaaaytoolong"
+
+        const res = await request(server)
+          .post("/api/auth/register")
+          .send(registration)
+        const actual = res.body.message
+
+        expect(actual).toMatch(expected)
+      })
+
+      it("returns 'username taken' when username already in use", async () => {
+        const expected = /username taken/i
+        registration.username = "willie-wonka"
 
         const res = await request(server)
           .post("/api/auth/register")
@@ -140,6 +153,7 @@ describe("[POST] /api/auth/register", () => {
 
         expect(actual).toMatch(expected)
       })
+
       it("returns 'password must be 8 characters or longer' when password is too short", async () => {
         const expected = /password must be 8 characters or longer/i
         registration.password = "short"
@@ -151,6 +165,7 @@ describe("[POST] /api/auth/register", () => {
 
         expect(actual).toMatch(expected)
       })
+
       it("returns 'password must be shorter than 64 characters' when password is too long", async () => {
         const expected = /password must be shorter than 64 characters/i
         registration.password = "waaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaytooooooooooooolong"
@@ -185,6 +200,7 @@ describe("[POST] /api/auth/register", () => {
 
         expect(actual).toMatch(expected)
       })
+
       it("returns 'email is invalid' when email is in invalid format", async () => {
         const expected = /email is invalid/i
         registration.email = "sheogorath"
@@ -221,6 +237,88 @@ describe("[POST] /api/auth/register", () => {
 
         expect(actual).toMatch(expected)
       })
+    })
+  })
+})
+
+describe("[POST] /api/auth/login", () => {
+  describe("success", () => {
+    let login
+    beforeEach(() => {
+      login = { username: "willie-wonka", password: "fun-times-ahead" }
+    })
+
+    it("responds with status code 200 upon successful login", async () => {
+      const expected = 200
+
+      const res = await request(server)
+        .post("/api/auth/login")
+        .send(login)
+      const actual = res.status
+
+      expect(actual).toBe(expected)
+    })
+
+    it("returns a welcome message and a login token", async () => {
+      const expectedMessage = /welcome, willie-wonka/i
+
+      const res = await request(server)
+        .post("/api/auth/login")
+        .send(login)
+      const actualMessage = res.body.message
+
+      expect(actualMessage).toMatch(expectedMessage)
+      expect(res.body).toHaveProperty("token")
+    })
+  })
+
+  describe("failure", () => {
+    it("responds with status code 400 when credentials are invalid", async () => {
+      const expected = 400
+      const login = { username: "willie-wonka", password: "badwrong" }
+
+      const res = await request(server)
+        .post("/api/auth/login")
+        .send(login)
+      const actual = res.status
+
+      expect(actual).toBe(expected)
+    })
+
+    it("returns message 'username is required' when username is missing", async () => {
+      const expected = /username is required/i
+      const login = { password: "badwrong" }
+
+      const res = await request(server)
+        .post("/api/auth/login")
+        .send(login)
+      const actual = res.body.message
+
+      expect(actual).toMatch(expected)
+    })
+
+    it("returns message 'password is required' when password is missing", async () => {
+      const expected = /password is required/i
+      const login = { username: "willie-wonka" }
+
+      const res = await request(server)
+        .post("/api/auth/login")
+        .send(login)
+      const actual = res.body.message
+
+      expect(actual).toMatch(expected)
+    })
+
+    it("returns message 'invalid credentials' when credentials are bad", async () => {
+      const expected = /invalid credentials/i
+      const login = { username: "willie-wonka", password: "badwrong" }
+
+      const res = await request(server)
+        .post("/api/auth/login")
+        .send(login)
+      const actual = res.body.message
+
+      expect(actual).toMatch(expected)
     })
   })
 })

--- a/api/users/users-model.js
+++ b/api/users/users-model.js
@@ -24,7 +24,6 @@ const add = async (user) => {
     .returning([
       "user_id",
       "username",
-      "password",
       "email"
     ])
   const newUser = insertResult[0]

--- a/endpoints.md
+++ b/endpoints.md
@@ -1,0 +1,90 @@
+# Endpoint Documentation
+
+The current endpoints for this backend are described, below.
+
+--------------------------------------------------------------------------------
+
+## Authentication
+
+Endpoints starting with `/api/auth` are related to the login/sign-up process.
+
+### Register
+
+**Endpoint**: `[POST] /api/auth/register`
+
+**Input**: pass in an object containing the following registration information...
+
+Key          | Type   | Required | Notes
+------------ | ------ | -------- | -----------------------------------------------------------
+username     | string | yes      | must be unqiue, and between 6-32 characters long
+password     | string | yes      | must be between 8-64 characters long
+email        | string | yes      | must be formatted as a real email (i.e. address@email.com)
+emailConfirm | string | yes      | must match the email provided in the `email` field, exactly
+
+**Output**: on success, returns an object in the following format...
+
+```
+{
+  "message": "New user registered, successfully!",
+  "user": {
+    "email": "highking@windhelm.net",
+    "user_id": 3,
+    "username": "ulfric-stormcloak"
+  }
+}
+```
+
+### Login
+
+**Endpoint**: `[POST] /api/auth/login`
+
+**Input**: pass in an object containing the following login information
+
+Key      | Type   | Required | Notes
+-------- | ------ | -------- | ------------------------------------------
+username | string | yes      | user must exist in the database
+password | string | yes      | password must be valid for the target user
+
+**Output**: on success, returns an object in the following format...
+
+```
+{
+  "message": "Welcome, ulfric-stormcloak!",
+  "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWJqZWN0IjozLCJ1c2VybmFtZSI6InVsZnJpYy1zdG9ybWNsb2FrIiwiZW1haWwiOiJoaWdoa2luZ0B3aW5kaGVsbS5uZXQiLCJpYXQiOjE2MzY4NTYwNDUsImV4cCI6MTYzNjg1NjM0NX0.FjboXxx-9hZFrogTM2Q3McWPqc8u7F0odJehfIQYQ-4"
+}
+```
+
+--------------------------------------------------------------------------------
+
+## Users
+
+Endpoints starting with `/api/users` are for fetching user information.
+
+### Get All Users
+
+**Endpoint**: `[GET] /api/users`
+
+**Output**: on success, returns an array of objects containing all the users in the database; this is for development purposes, and will likely go unused in the final release
+
+```
+[
+  {
+    "email": "willie@wonka.com",
+    "password": "$2a$06$GpPRvzwBls/o5Ixmv9jgEOHgR6wL08EZCjMfd5uK4mOan7RtVdVlm",
+    "user_id": 1,
+    "username": "willie-wonka"
+  },
+  {
+    "email": "pebbles@thecursediterator.net",
+    "password": "$2a$06$JwUBB7BzdMC9XKaMu4dPp.ObsMjelOEfYqhvSm/bihtdIYNzBCNtm",
+    "user_id": 2,
+    "username": "five-pebbles"
+  },
+  {
+    "email": "highking@windhelm.net",
+    "password": "$2a$06$I/RDKeqftecWTrkfM/cML.kOHThOAQbeldYIiv7xqySbO7q.SRDvG",
+    "user_id": 3,
+    "username": "ulfric-stormcloak"
+  }
+]
+```


### PR DESCRIPTION
This branch contains changes/additions to implement a working login system using JSON web tokens.

### Additions

- New Endpoint: `[POST] /api/auth/login`  | { username (string), password (string) }
  - This endpoint allows registered users to sign in
  - On success, the client will receive an object containing a success message and a login token
    - The login token currently expires after 5 minutes; this is for development purposes, and this expiration time will be adjusted in the future
  - Automated tests with Jest have been included to account for potential errors in payload, different status codes, and response messages
- An additional registration test has been added to account for failed registration caused by a username already being taken
- A markdown file documenting the current endpoints has been added to the root of the project

### Changes

- The password key has been removed from the response body of successful registration attempts
  - There is no need for a user to see a password hash; this was a placeholder from initial scaffolding
  - A `/api/auth/register` test was adjusted to account for this change
- Validation middlewares were refactored for simplicity; redundant lines of code were cut for clarity
- Endpoint documentation has been linked in the `README.md` file