### PR TITLE
Feature: Delete Classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Anywhere Fitness (Back End)
 
-Latest Version: 0.6.0 ([Patch Notes](https://github.com/WaywardPooch/anywhere-fitness-backend/pull/5))
+Latest Version: 0.7.0 ([Patch Notes](https://github.com/WaywardPooch/anywhere-fitness-backend/pull/6))
 
 ## DISCLAIMER!
 

--- a/api/auth/token-builder.js
+++ b/api/auth/token-builder.js
@@ -7,11 +7,12 @@ const buildToken = user => {
     subject: user.id,
     user_id: user.id,
     username: user.username,
+    name: user.name,
     email: user.email,
     role_id: user.role_id
   }
   const options = {
-    expiresIn: "5m"
+    expiresIn: "15m"
   }
   const signedToken = jwt.sign(payload, JWT_SECRET, options)
   return signedToken

--- a/api/fitness-classes/fitness-classes-model.js
+++ b/api/fitness-classes/fitness-classes-model.js
@@ -102,10 +102,19 @@ async function addClient(class_client) {
   return record
 }
 
+async function removeById(classId) {
+  const deletedRecords = await db("classes")
+    .where({ class_id: classId })
+    .del()
+    .returning(["class_id"])
+  return deletedRecords
+}
+
 module.exports = {
   add,
   addClient,
   filterBy,
   getAll,
-  getById
+  getById,
+  removeById
 }

--- a/api/fitness-classes/fitness-classes-router.js
+++ b/api/fitness-classes/fitness-classes-router.js
@@ -5,7 +5,7 @@ const { validateNewFitnessClass } = require("../middleware/validate-class")
 const checkIfLoggedIn = require("../middleware/check-logged-in")
 const decodeToken = require("../auth/token-decoder")
 const { JWT_SECRET } = require("../../config")
-const checkIfInstructor = require("../middleware/check-instructor")
+const { checkIfInstructor, checkIfClassOwner } = require("../middleware/check-instructor")
 const checkClassNameTaken = require("../middleware/check-classname-taken")
 
 router.get("/",
@@ -77,6 +77,22 @@ router.get("/:id/join",
       await FitnessClass.addClient({ user_id, class_id })
       res.status(200).json({
         message: "Successfully joined class!"
+      })
+    } catch (err) {
+      next(err)
+    }
+  }
+)
+
+router.delete("/:id",
+  checkFitnessClassId,
+  checkIfClassOwner,
+  async (req, res, next) => {
+    try {
+      const class_id = req.params.id
+      await FitnessClass.removeById(class_id)
+      res.status(200).json({
+        message: "Successfully deleted class!"
       })
     } catch (err) {
       next(err)

--- a/api/middleware/check-instructor.js
+++ b/api/middleware/check-instructor.js
@@ -16,4 +16,24 @@ function checkIfInstructor(req, res, next) {
   }
 }
 
-module.exports = checkIfInstructor
+function checkIfClassOwner(req, res, next) {
+  const instructor = req.custom_class.instructor
+
+  const token = req.headers.authorization
+  const tokenPayload = decodeToken(token, JWT_SECRET)
+  const { name } = tokenPayload
+
+  if (name !== instructor) {
+    next({
+      status: 401,
+      message: "access denied"
+    })
+  } else {
+    next()
+  }
+}
+
+module.exports = {
+  checkIfInstructor,
+  checkIfClassOwner
+}

--- a/api/server.spec.js
+++ b/api/server.spec.js
@@ -1050,7 +1050,7 @@ describe("[GET] /api/classes/:id/join", () => {
 
 describe("[DELETE] /api/classes/:id", () => {
   let token
-  beforeEach(async () => {
+  beforeAll(async () => {
     const loginRes = await request(server)
       .post("/api/auth/login")
       .send({
@@ -1081,6 +1081,19 @@ describe("[DELETE] /api/classes/:id", () => {
       const actual = res.body.message
 
       expect(actual).toMatch(expected)
+    })
+
+    it("can delete a class from db", async () => {
+      const expected = 4
+
+      await request(server)
+        .delete("/api/classes/1")
+        .set("Authorization", token)
+      const res = await request(server)
+        .get("/api/classes")
+      const actual = res.body
+
+      expect(actual).toHaveLength(expected)
     })
   })
 

--- a/api/server.spec.js
+++ b/api/server.spec.js
@@ -1049,20 +1049,86 @@ describe("[GET] /api/classes/:id/join", () => {
 
 
 describe("[DELETE] /api/classes/:id", () => {
-  describe("success", () => {
-    it.todo("responds with status code 200")
-    it.todo("returns a success message")
+  let token
+  beforeEach(async () => {
+    const loginRes = await request(server)
+      .post("/api/auth/login")
+      .send({
+        username: "johnsnow",
+        password: TEST_PASSWORD
+      })
+    token = loginRes.body.token
   })
+
+  describe("success", () => {
+    it("responds with status code 200", async () => {
+      const expected = 200
+
+      const res = await request(server)
+        .delete("/api/classes/1")
+        .set("Authorization", token)
+      const actual = res.status
+
+      expect(actual).toBe(expected)
+    })
+
+    it("returns a success message", async () => {
+      const expected = /class deleted successfully/i
+
+      const res = await request(server)
+        .delete("/api/classes/1")
+        .set("Authorization", token)
+      const actual = res.status
+
+      expect(actual).toMatch(expected)
+    })
+  })
+
 
   describe("failure", () => {
     describe("unauthorized", () => {
-      it.todo("responds with status code 401")
-      it.todo("returns 'access denied' error")
+      it("responds with status code 401", async () => {
+        const expected = 401
+
+        const res = await request(server)
+          .delete("/api/classes/1")
+        const actual = res.status
+
+        expect(actual).toBe(expected)
+      })
+
+      it("returns 'access denied' error", async () => {
+        const expected = /access denied/i
+
+        const res = await request(server)
+          .delete("/api/classes/1")
+          .set("Authorization", "badwrong")
+        const actual = res.body.message
+
+        expect(actual).toMatch(expected)
+      })
     })
 
     describe("invalid class ID", () => {
-      it.todo("responds with status code 404")
-      it.todo("returns 'class not found' error")
+      it("responds with status code 404", async () => {
+        const expected = 404
+
+        const res = await request(server)
+          .delete("/api/classes/121")
+        const actual = res.status
+
+        expect(actual).toBe(expected)
+      })
+
+      it("returns 'class does not exist' error", async () => {
+        const expected = /class does not exist found/i
+
+        const res = await request(server)
+          .delete("/api/classes/121")
+        const actual = res.body.message
+
+        expect(actual).toMatch(expected)
+      })
     })
   })
 })

--- a/api/server.spec.js
+++ b/api/server.spec.js
@@ -1073,12 +1073,12 @@ describe("[DELETE] /api/classes/:id", () => {
     })
 
     it("returns a success message", async () => {
-      const expected = /class deleted successfully/i
+      const expected = /successfully deleted class/i
 
       const res = await request(server)
         .delete("/api/classes/1")
         .set("Authorization", token)
-      const actual = res.status
+      const actual = res.body.message
 
       expect(actual).toMatch(expected)
     })
@@ -1115,16 +1115,18 @@ describe("[DELETE] /api/classes/:id", () => {
 
         const res = await request(server)
           .delete("/api/classes/121")
+          .set("Authorization", token)
         const actual = res.status
 
         expect(actual).toBe(expected)
       })
 
-      it("returns 'class does not exist' error", async () => {
-        const expected = /class does not exist found/i
+      it("returns 'class not found' error", async () => {
+        const expected = /class not found/i
 
         const res = await request(server)
           .delete("/api/classes/121")
+          .set("Authorization", token)
         const actual = res.body.message
 
         expect(actual).toMatch(expected)

--- a/api/server.spec.js
+++ b/api/server.spec.js
@@ -1044,6 +1044,25 @@ describe("[GET] /api/classes/:id/join", () => {
         expect(actual).toMatch(expected)
       })
     })
+  })
+})
 
+
+describe("[DELETE] /api/classes/:id", () => {
+  describe("success", () => {
+    it.todo("responds with status code 200")
+    it.todo("returns a success message")
+  })
+
+  describe("failure", () => {
+    describe("unauthorized", () => {
+      it.todo("responds with status code 401")
+      it.todo("returns 'access denied' error")
+    })
+
+    describe("invalid class ID", () => {
+      it.todo("responds with status code 404")
+      it.todo("returns 'class not found' error")
+    })
   })
 })

--- a/data/migrations/20211117153843_join-classes.js
+++ b/data/migrations/20211117153843_join-classes.js
@@ -12,9 +12,11 @@ exports.up = function (knex) {
       table.foreign("class_id")
         .references("class_id")
         .on("classes")
+        .onDelete("CASCADE")
       table.foreign("user_id")
         .references("user_id")
         .on("users")
+        .onDelete("CASCADE")
     })
 }
 

--- a/endpoints.md
+++ b/endpoints.md
@@ -194,6 +194,22 @@ This endpoint requires a token in the header to know who's making the request. C
 }
 ```
 
+### Delete a Class
+
+This endpoint requires the person making the request to be the instructor who created the class; only instructors who actually made the class can delete it
+
+**Endpoint**: `[DELETE] /api/classes/:id`
+
+**Parameters**: `:id` must be an integer, representing a fitness class's ID
+
+**Output**: returns a success message
+
+```
+{
+  "message": "Successfully deleted class!"
+}
+```
+
 --------------------------------------------------------------------------------
 
 ## Users

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anywhere-fitness-backend",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "description": "This is the backend repository for Lambda School's \"Build Week\" Full-Time program, Group #5",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anywhere-fitness-backend",
-  "version": "0.6.0",
+  "version": "0.6.4",
   "description": "This is the backend repository for Lambda School's \"Build Week\" Full-Time program, Group #5",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
This branch allows instructors to delete classes they've made via a new endpoint.

### Additions

- `[DELETE] /api/classes/:id` allows logged-in instructors who own the class to delete the class they made
  - Endpoint is tested in `server.spec.js`
- New middleware is implemented to check if a class's instructor name matches the logged in user's name

### Changes

- Migration for the `classes_clients` table was adjusted to cascade foreign key deletion
- `endpoints.md` was updated to account for the new endpoint
- Login tokens now last for 15 minutes, instead of 5 minutes

### Known Bugs

- Instructors are not added to a class's attendees list, meaning an instructor can't fetch classes they own to allow them to delete said classes from the front-end; this will need to be fixed in the next update